### PR TITLE
Fix reading always 0 because of common SDIO

### DIFF
--- a/Adns5050.cpp
+++ b/Adns5050.cpp
@@ -82,7 +82,9 @@ unsigned char Adns5050::read (const ADNS_5050_reg address)
 #endif
 	}
 
+	pinMode(MOSI, INPUT);
 	recv = SPI.transfer((unsigned char)0);
+	pinMode(MOSI, OUTPUT);
 #ifdef ADNS_50x0_DEBUG
 	Serial.print("ADNS.SDIO >> 0x");
 	Serial.println(recv, HEX);


### PR DESCRIPTION
There was an issue when reading any register of the ADNS5050. In the example circuit shown in its datasheet, the ADNS5050 only has an SDIO pin instead of a separate SDI and SDO, so both MISO and MOSI of the IC must be connected to the same pin. 

The dummy value used to perform the SPI transfer was interfering with the actual reading of the register.

By setting the MOSI pin of the arduino to INPUT temporarily, we can successfully read the correct value of the register.